### PR TITLE
fix: Fixup reading of deleted v2 tokens;

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,7 +4,9 @@ quarkus.locales=en-US
 quarkus.default-locale=en-US
 
 # Backend type (inmemory or vault)
-spi.backend.type=inmemory
+spi.backend.type=vault
+quarkus.vault.url=http://localhost:8200
+quarkus.vault.authentication.client-token=s.wvZdSkkbmczNhIFeX7qrnBvu
 
 ### log
 ### Console

--- a/src/test/java/org/redhat/appstudio/serviceprovider/service/storage/integration/VaultAccessTokenServiceTest.java
+++ b/src/test/java/org/redhat/appstudio/serviceprovider/service/storage/integration/VaultAccessTokenServiceTest.java
@@ -14,6 +14,7 @@ package org.redhat.appstudio.serviceprovider.service.storage.integration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import io.quarkus.test.junit.QuarkusTest;
@@ -114,6 +115,18 @@ class VaultAccessTokenServiceTest {
         fail("Incorrect code status");
       }
     }
+  }
+
+  @Test
+  public void testGetRemovedV2Token() {
+    // Pre-write token
+    final String secretName = NameGenerator.generate("name-", 6);
+    final Map<String, String> tokenMap = tokenAsMap(secretName);
+    vaultKvManager.writeSecret(vaultPath + "/" + secretName, tokenMap);
+    service.delete(secretName);
+
+    Optional<AccessToken> token = service.get(vaultPath + "/" + secretName);
+    assertTrue(token.isEmpty());
   }
 
   private Map<String, String> tokenAsMap(String name) {

--- a/src/test/java/org/redhat/appstudio/serviceprovider/service/storage/integration/VaultAccessTokenServiceTest.java
+++ b/src/test/java/org/redhat/appstudio/serviceprovider/service/storage/integration/VaultAccessTokenServiceTest.java
@@ -24,6 +24,7 @@ import io.quarkus.vault.runtime.client.VaultClientException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import javax.inject.Inject;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -127,6 +128,24 @@ class VaultAccessTokenServiceTest {
 
     Optional<AccessToken> token = service.get(vaultPath + "/" + secretName);
     assertTrue(token.isEmpty());
+  }
+
+  @Test
+  public void testListAfterRemovedV2Token() {
+    // Pre-write tokens
+    final String secretName1 = NameGenerator.generate("name-", 6);
+    vaultKvManager.writeSecret(vaultPath + "/" + secretName1, tokenAsMap(secretName1));
+
+    final String secretName2 = NameGenerator.generate("name-", 6);
+    vaultKvManager.writeSecret(vaultPath + "/" + secretName2, tokenAsMap(secretName2));
+
+    final String secretName3 = NameGenerator.generate("name-", 6);
+    vaultKvManager.writeSecret(vaultPath + "/" + secretName3, tokenAsMap(secretName3));
+
+    service.delete(secretName2);
+
+    Set<AccessToken> tokens = service.fetchAll();
+    assertEquals(2, tokens.size());
   }
 
   private Map<String, String> tokenAsMap(String name) {


### PR DESCRIPTION
### What does this PR do?
Fixup reading/list of tokens is some are deleted on V2 engine;

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->


### How to test this PR?
- Run on Vault;
- Create 3 tokens;
- Remove one;
- Get list. Before: list is empty. After: list is 2 items.
